### PR TITLE
Assign emtry object to 'current' instead of null by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const hooks = require( 'async_hooks' )
 
 const cls = {}
-let current = null
+let current = {}
 const HOLD = "$HOLD"
 
 hooks
@@ -14,7 +14,7 @@ hooks
             current = cls[ id ] = cls[id] || {}
         },
         after () {
-            current = null
+            current = {}
         },
         destroy ( id ) {
             delete cls[ id ]


### PR DESCRIPTION
There is an issue with trying to set a value to the storage if you do it NOT in request handlers. 
For example, this code will work fine:
```
import scls from 'simple-continuation-local-storage';

const handler = (req, res) => {
    scls.$init();
    scls.foo = 'bar';
}

http.createServer(handler).listen(7777);
```

But this code will throw an error:
```
import scls from 'simple-continuation-local-storage';

scls.$init();
scls.foo = 'bar';
```

The error:
````
TypeError: 'set' on proxy: trap returned falsish for property 'foo'
````

This happens because Proxy's 'set' returns false because 'current' is null at that moment.

To fix this I've changed the default value of 'current" from null to an empty object.
My concern is that this change alters the logic in a couple of places...

What do you think, @mike_talbot?